### PR TITLE
Gb edf metadata adapter

### DIFF
--- a/metadata_app.py
+++ b/metadata_app.py
@@ -1,8 +1,7 @@
 import dash
 from dash import html
 
-from callbacks.metadata_interface import * #noqa: F401, F403
-
+from callbacks.metadata_interface import *  # noqa: F401, F403
 from components.metadata_interface import (
     interface_components,
     table_modification_components,

--- a/tiled/config/custom/gb.py
+++ b/tiled/config/custom/gb.py
@@ -94,19 +94,21 @@ def parse_edf_accompanying_gb(file_path):
         edf_hi_filepath = file_path.with_suffix(".edf")
         edf_hi_filepath = pathlib.Path(str(edf_hi_filepath).replace("sfloat", "hi"))
 
-    # File does not exist, return empty dictionary
+    # File does not exist, set the date as None - empty metadata dictionary is 
+    # returned in the parse_txt_accompanying_edf method
     if not os.path.isfile(edf_hi_filepath):
-        return dict()
-    
-    #extract the header information and import the function for edf and read the metadata
-    # take the metadata from both and if the same key is present in both, keep the values of both   
-    # but index it with hi and lo
-
-    hi_file = fabio.open(edf_hi_filepath)
-    hi_header = hi_file.header
-    hi_date = hi_header.get("Date")
+        #edf_hi_metadata_dict = dict()
+        hi_date = None
+    else:
+        hi_file = fabio.open(edf_hi_filepath)
+        hi_header = hi_file.header
+        hi_date = hi_header.get("Date")
     
     edf_hi_metadata_dict = parse_txt_accompanying_edf(edf_hi_filepath)
+    
+    # extract the header information and import the function for edf and read the metadata
+    # take the metadata from both and if the same key is present in both, keep the values of both   
+    # but index it with hi and lo
 
     edf_lo_filepath = None
     if isinstance(file_path, str):
@@ -115,13 +117,15 @@ def parse_edf_accompanying_gb(file_path):
         edf_lo_filepath = file_path.with_suffix(".edf")
         edf_lo_filepath = pathlib.Path(str(edf_lo_filepath).replace("sfloat", "lo"))
 
-    # File does not exist, return empty dictionary
+    # File does not exist, set the date as None - empty metadata dictionary is 
+    # returned in the parse_txt_accompanying_edf method
     if not os.path.isfile(edf_lo_filepath):
-        return dict()
-    
-    lo_file = fabio.open(edf_lo_filepath)
-    lo_header = lo_file.header
-    lo_date = lo_header.get("Date")
+        #edf_lo_metadata_dict = dict()
+        lo_date = None
+    else: 
+        lo_file = fabio.open(edf_lo_filepath)
+        lo_header = lo_file.header
+        lo_date = lo_header.get("Date")
     
     edf_lo_metadata_dict = parse_txt_accompanying_edf(edf_lo_filepath)
 
@@ -129,7 +133,10 @@ def parse_edf_accompanying_gb(file_path):
     gb_dictionary = combine_edf_metadata_for_gb(edf_hi_metadata_dict, edf_lo_metadata_dict)
 
     # Compare two dates and select the later one
-    gb_dictionary["Date"] = hi_date if hi_date > lo_date else lo_date
+    if hi_date is not None and lo_date is not None:
+        gb_dictionary["Date"] = hi_date if hi_date > lo_date else lo_date
+    else:
+        gb_dictionary["Date"] = hi_date if hi_date is not None else lo_date
 
     return gb_dictionary
 

--- a/tiled/config/custom/gb.py
+++ b/tiled/config/custom/gb.py
@@ -144,9 +144,9 @@ def parse_edf_accompanying_gb(file_path):
 
     # Compare two dates and select the later one, but the string version for better readability
     if hi_date is not None and lo_date is not None:
-        gb_dictionary["Date"] = hi_date_str if hi_date > lo_date else lo_date_str
+        gb_dictionary["Date"] = hi_date if hi_date > lo_date else lo_date
     else:
-        gb_dictionary["Date"] = hi_date_str if hi_date is not None else lo_date_str
+        gb_dictionary["Date"] = hi_date if hi_date is not None else lo_date
 
     return gb_dictionary
 

--- a/tiled/config/custom/gb.py
+++ b/tiled/config/custom/gb.py
@@ -8,6 +8,7 @@ import os
 import logging
 from logging import StreamHandler
 import fabio
+from datetime import datetime
 
 logger = logging.getLogger("tiled.adapters.edf")
 logger.addHandler(StreamHandler())
@@ -108,7 +109,9 @@ def parse_edf_accompanying_gb(file_path):
     else:
         hi_file = fabio.open(edf_hi_filepath)
         hi_header = hi_file.header
-        hi_date = hi_header.get("Date")
+        hi_date_str = hi_header.get("Date")
+        # Parse the string to convert to datetime object
+        hi_date = datetime.strptime(hi_date_str, '%a %b %d %H:%M:%S %Y')
         #  Combine the metadata dictionaries - from header and .txt file
         edf_hi_metadata_dict = {**edf_hi_metadata_dict, **hi_header}
 
@@ -130,18 +133,20 @@ def parse_edf_accompanying_gb(file_path):
     else: 
         lo_file = fabio.open(edf_lo_filepath)
         lo_header = lo_file.header
-        lo_date = lo_header.get("Date")
+        lo_date_str = lo_header.get("Date")
+        # Parse the string to convert to datetime object
+        lo_date = datetime.strptime(lo_date_str, '%a %b %d %H:%M:%S %Y')
         #  Combine the metadata dictionaries - from header and .txt file
         edf_lo_metadata_dict = {**edf_lo_metadata_dict, **lo_header}
 
     # Combine the metadata dictionaries
     gb_dictionary = combine_edf_metadata_for_gb(edf_hi_metadata_dict, edf_lo_metadata_dict)
 
-    # Compare two dates and select the later one
+    # Compare two dates and select the later one, but the string version for better readability
     if hi_date is not None and lo_date is not None:
-        gb_dictionary["Date"] = hi_date if hi_date > lo_date else lo_date
+        gb_dictionary["Date"] = hi_date_str if hi_date > lo_date else lo_date_str
     else:
-        gb_dictionary["Date"] = hi_date if hi_date is not None else lo_date
+        gb_dictionary["Date"] = hi_date_str if hi_date is not None else lo_date_str
 
     return gb_dictionary
 

--- a/tiled/config/custom/gb.py
+++ b/tiled/config/custom/gb.py
@@ -1,14 +1,15 @@
+import logging
+import os
+import pathlib
+from datetime import datetime
+from logging import StreamHandler
+
+import fabio
 import numpy as np
+from custom.edf import parse_txt_accompanying_edf
 from tiled.adapters.array import ArrayAdapter
 from tiled.structures.core import Spec
 from tiled.utils import path_from_uri
-from custom.edf import parse_txt_accompanying_edf
-import pathlib
-import os
-import logging
-from logging import StreamHandler
-import fabio
-from datetime import datetime
 
 logger = logging.getLogger("tiled.adapters.edf")
 logger.addHandler(StreamHandler())
@@ -35,20 +36,23 @@ def read(data_uri, structure=None, metadata=None, specs=None, access_policy=None
     array = data.reshape((pixels_y, pixels_x))
 
     additional_edf_metadata = parse_edf_accompanying_gb(filepath)
-    
-    # Combine the metadata dictionaries - the following method combines the 
+
+    # Combine the metadata dictionaries - the following method combines the
     # metadata dictionaries but there is a potential to overwrrite the values
     # for the same keys. If same keys are present in both dictionaries, then
     # an alternate method should be used to combine the dictionaries, similar to
     # the one used in the combine_edf_metadata_for_gb method.
-    metadata = {**metadata, **additional_edf_metadata} if metadata else additional_edf_metadata
+    metadata = (
+        {**metadata, **additional_edf_metadata} if metadata else additional_edf_metadata
+    )
 
     return ArrayAdapter.from_array(array, metadata=metadata, specs=[Spec("gb")])
+
 
 def combine_edf_metadata_for_gb(hi_dict, lo_dict):
     """Combine two dictionaries into one.
 
-    Take the metadata from both and if the same key is present in both, 
+    Take the metadata from both and if the same key is present in both,
     keep the values of both but index it with hi and lo
 
     Parameters
@@ -102,8 +106,9 @@ def parse_edf_accompanying_gb(file_path):
 
     # If the .txt file exists, the metadata is extracted from it
     # In case the .txt file does not exist:
-    #  - set the date as None,  
-    #  - An empty metadata dictionary is initilized (returned from parse_txt_accompanying_edf())
+    #  - set the date as None,
+    #  - An empty metadata dictionary is initilized (returned from
+    #                                   parse_txt_accompanying_edf())
     if not os.path.isfile(edf_hi_filepath):
         hi_date = None
     else:
@@ -111,7 +116,7 @@ def parse_edf_accompanying_gb(file_path):
         hi_header = hi_file.header
         hi_date_str = hi_header.get("Date")
         # Parse the string to convert to datetime object
-        hi_date = datetime.strptime(hi_date_str, '%a %b %d %H:%M:%S %Y')
+        hi_date = datetime.strptime(hi_date_str, "%a %b %d %H:%M:%S %Y")
         #  Combine the metadata dictionaries - from header and .txt file
         edf_hi_metadata_dict = {**edf_hi_metadata_dict, **hi_header}
 
@@ -123,30 +128,33 @@ def parse_edf_accompanying_gb(file_path):
         edf_lo_filepath = pathlib.Path(str(edf_lo_filepath).replace("sfloat", "lo"))
 
     edf_lo_metadata_dict = parse_txt_accompanying_edf(edf_lo_filepath)
-    
+
     # If the .txt file exists, the metadata is extracted from it
     # In case the .txt file does not exist:
-    #  - set the date as None,  
-    #  - An empty metadata dictionary is initilized (returned from parse_txt_accompanying_edf())
+    #  - set the date as None,
+    #  - An empty metadata dictionary is initilized (returned from
+    #                                   parse_txt_accompanying_edf())
     if not os.path.isfile(edf_lo_filepath):
         lo_date = None
-    else: 
+    else:
         lo_file = fabio.open(edf_lo_filepath)
         lo_header = lo_file.header
         lo_date_str = lo_header.get("Date")
         # Parse the string to convert to datetime object
-        lo_date = datetime.strptime(lo_date_str, '%a %b %d %H:%M:%S %Y')
+        lo_date = datetime.strptime(lo_date_str, "%a %b %d %H:%M:%S %Y")
         #  Combine the metadata dictionaries - from header and .txt file
         edf_lo_metadata_dict = {**edf_lo_metadata_dict, **lo_header}
 
     # Combine the metadata dictionaries
-    gb_dictionary = combine_edf_metadata_for_gb(edf_hi_metadata_dict, edf_lo_metadata_dict)
+    gb_dictionary = combine_edf_metadata_for_gb(
+        edf_hi_metadata_dict, edf_lo_metadata_dict
+    )
 
-    # Compare two dates and select the later one, but the string version for better readability
+    # Compare two dates and select the later one,
+    # but the string version for better readability
     if hi_date is not None and lo_date is not None:
         gb_dictionary["Date"] = hi_date if hi_date > lo_date else lo_date
     else:
         gb_dictionary["Date"] = hi_date if hi_date is not None else lo_date
 
     return gb_dictionary
-

--- a/tiled/config/custom/gb.py
+++ b/tiled/config/custom/gb.py
@@ -47,6 +47,9 @@ def read(data_uri, structure=None, metadata=None, specs=None, access_policy=None
 def combine_edf_metadata_for_gb(hi_dict, lo_dict):
     """Combine two dictionaries into one.
 
+    Take the metadata from both and if the same key is present in both, 
+    keep the values of both but index it with hi and lo
+
     Parameters
     ----------
     hi_dict: dict
@@ -94,6 +97,8 @@ def parse_edf_accompanying_gb(file_path):
         edf_hi_filepath = file_path.with_suffix(".edf")
         edf_hi_filepath = pathlib.Path(str(edf_hi_filepath).replace("sfloat", "hi"))
 
+    edf_hi_metadata_dict = parse_txt_accompanying_edf(edf_hi_filepath)
+
     # If the .txt file exists, the metadata is extracted from it
     # In case the .txt file does not exist:
     #  - set the date as None,  
@@ -104,12 +109,8 @@ def parse_edf_accompanying_gb(file_path):
         hi_file = fabio.open(edf_hi_filepath)
         hi_header = hi_file.header
         hi_date = hi_header.get("Date")
-    
-    edf_hi_metadata_dict = parse_txt_accompanying_edf(edf_hi_filepath)
-    
-    # extract the header information and import the function for edf and read the metadata
-    # take the metadata from both and if the same key is present in both, keep the values of both   
-    # but index it with hi and lo
+        #  Combine the metadata dictionaries - from header and .txt file
+        edf_hi_metadata_dict = {**edf_hi_metadata_dict, **hi_header}
 
     edf_lo_filepath = None
     if isinstance(file_path, str):
@@ -118,6 +119,8 @@ def parse_edf_accompanying_gb(file_path):
         edf_lo_filepath = file_path.with_suffix(".edf")
         edf_lo_filepath = pathlib.Path(str(edf_lo_filepath).replace("sfloat", "lo"))
 
+    edf_lo_metadata_dict = parse_txt_accompanying_edf(edf_lo_filepath)
+    
     # If the .txt file exists, the metadata is extracted from it
     # In case the .txt file does not exist:
     #  - set the date as None,  
@@ -128,8 +131,8 @@ def parse_edf_accompanying_gb(file_path):
         lo_file = fabio.open(edf_lo_filepath)
         lo_header = lo_file.header
         lo_date = lo_header.get("Date")
-    
-    edf_lo_metadata_dict = parse_txt_accompanying_edf(edf_lo_filepath)
+        #  Combine the metadata dictionaries - from header and .txt file
+        edf_lo_metadata_dict = {**edf_lo_metadata_dict, **lo_header}
 
     # Combine the metadata dictionaries
     gb_dictionary = combine_edf_metadata_for_gb(edf_hi_metadata_dict, edf_lo_metadata_dict)

--- a/tiled/config/custom/gb.py
+++ b/tiled/config/custom/gb.py
@@ -2,6 +2,16 @@ import numpy as np
 from tiled.adapters.array import ArrayAdapter
 from tiled.structures.core import Spec
 from tiled.utils import path_from_uri
+#from tiled.config.custom.edf import parse_txt_accompanying_edf
+import pathlib
+import os
+import logging
+from logging import StreamHandler
+import fabio
+
+logger = logging.getLogger("tiled.adapters.edf")
+logger.addHandler(StreamHandler())
+logger.setLevel("INFO")
 
 
 def read(data_uri, structure=None, metadata=None, specs=None, access_policy=None):
@@ -24,3 +34,94 @@ def read(data_uri, structure=None, metadata=None, specs=None, access_policy=None
     array = data.reshape((pixels_y, pixels_x))
 
     return ArrayAdapter.from_array(array, metadata=metadata, specs=[Spec("gb")])
+
+def combine_edf_metadata_for_gb(hi_dict, lo_dict):
+    """Combine two dictionaries into one.
+
+    Parameters
+    ----------
+    hi_dict: dict
+        Dictionary containing metadata from the hi .edf file.
+    lo_dict: dict
+        Dictionary containing metadata from the lo .edf file
+    """
+    combined_dict = dict()
+
+    # get all the unique keys from both dictionaries
+    combined_keys = set(hi_dict.keys()).union(set(lo_dict.keys()))
+
+    # check if the values match for the same key in both dictionaries
+    for key in combined_keys:
+        hi_val = hi_dict.get(key)
+        lo_val = lo_dict.get(key)
+
+        if hi_val == lo_val:
+            # If values are the same, keep one entry
+            combined_dict[key] = hi_val
+        else:
+            # If values are different, add both with distinct keys
+            if hi_val is not None:
+                combined_dict[f"{key}_hi"] = hi_val
+            if lo_val is not None:
+                combined_dict[f"{key}_lo"] = lo_val
+
+    return combined_dict
+
+
+def parse_edf_accompanying_gb(file_path):
+    """Parse a .edf file produced at ALS beamline 7.3.3 into a dictionary.
+
+    Parameters
+    ----------
+    file_path: str or pathlib.Path
+        Filepath of the .edf file.
+    """
+
+    # Generate the hi edf file path
+    edf_hi_filepath = None
+    if isinstance(file_path, str):
+        edf_hi_filepath = file_path.replace("sfloat_2m.gb", "hi_2m.edf")
+    if isinstance(file_path, pathlib.Path):
+        edf_hi_filepath = file_path.with_suffix(".edf")
+        edf_hi_filepath = edf_hi_filepath.replace("sfloat", "hi")
+
+    # File does not exist, return empty dictionary
+    if not os.path.isfile(edf_hi_filepath):
+        return dict()
+    
+    #extract the header information and import the function for edf and read the metadata
+    # take the metadata from both and if the same key is present in both, keep the values of both   
+    # but index it with hi and lo
+
+    hi_file = fabio.open(edf_hi_filepath)
+    hi_header = hi_file.header
+    hi_date = hi_header.get("Date")
+    
+    edf_hi_metadata_dict = parse_txt_accompanying_edf(edf_hi_filepath)
+
+    edf_lo_filepath = None
+    if isinstance(file_path, str):
+        edf_lo_filepath = file_path.replace("sfloat_2m.gb", "lo_2m.edf")
+    if isinstance(file_path, pathlib.Path):
+        edf_lo_filepath = file_path.with_suffix(".edf")
+        edf_lo_filepath = edf_lo_filepath.replace("sfloat", "lo")
+
+    # File does not exist, return empty dictionary
+    if not os.path.isfile(edf_lo_filepath):
+        return dict()
+    
+    lo_file = fabio.open(edf_lo_filepath)
+    lo_header = lo_file.header
+    lo_date = lo_header.get("Date")
+    
+    edf_lo_metadata_dict = parse_txt_accompanying_edf(edf_lo_filepath)
+
+    # Combine the metadata dictionaries
+    gb_dictionary = combine_edf_metadata_for_gb(edf_hi_metadata_dict, edf_lo_metadata_dict)
+    print(gb_dictionary)
+
+    # Compare two dates and select the later one
+    gb_dictionary["Date"] = hi_date if hi_date > lo_date else lo_date
+
+    return gb_dictionary
+

--- a/tiled/config/custom/gb.py
+++ b/tiled/config/custom/gb.py
@@ -94,10 +94,11 @@ def parse_edf_accompanying_gb(file_path):
         edf_hi_filepath = file_path.with_suffix(".edf")
         edf_hi_filepath = pathlib.Path(str(edf_hi_filepath).replace("sfloat", "hi"))
 
-    # File does not exist, set the date as None - empty metadata dictionary is 
-    # returned in the parse_txt_accompanying_edf method
+    # If the .txt file exists, the metadata is extracted from it
+    # In case the .txt file does not exist:
+    #  - set the date as None,  
+    #  - An empty metadata dictionary is initilized (returned from parse_txt_accompanying_edf())
     if not os.path.isfile(edf_hi_filepath):
-        #edf_hi_metadata_dict = dict()
         hi_date = None
     else:
         hi_file = fabio.open(edf_hi_filepath)
@@ -117,10 +118,11 @@ def parse_edf_accompanying_gb(file_path):
         edf_lo_filepath = file_path.with_suffix(".edf")
         edf_lo_filepath = pathlib.Path(str(edf_lo_filepath).replace("sfloat", "lo"))
 
-    # File does not exist, set the date as None - empty metadata dictionary is 
-    # returned in the parse_txt_accompanying_edf method
+    # If the .txt file exists, the metadata is extracted from it
+    # In case the .txt file does not exist:
+    #  - set the date as None,  
+    #  - An empty metadata dictionary is initilized (returned from parse_txt_accompanying_edf())
     if not os.path.isfile(edf_lo_filepath):
-        #edf_lo_metadata_dict = dict()
         lo_date = None
     else: 
         lo_file = fabio.open(edf_lo_filepath)


### PR DESCRIPTION
This branch deals with the adapter for .gb files. Additional functionality has been added for .gb file ingestion. The goal is to take metadata associated with the .edf images associated to the respective sfloat .gb image: the hi and lo  .edf images. The helper function create new indices if the same key exists with different values in the hi and low images' metadata, in order to not lose information. 

The current version works in ingesting .gb files when there are .edf files with the associated .txt files. But there is a bug when ingesting a folder with just .gb files. This adapter needs debugging. The current terminal output looks like this:

<img width="1045" alt="Screenshot 2024-12-04 at 8 01 41 PM" src="https://github.com/user-attachments/assets/bf5df9fc-98aa-4a53-987c-9d31077225b3">

with a final error statement of: ```AttributeError: 'NoneType' object has no attribute 'new'```