### PR TITLE
powereshell script update for tiled_catalog_register.ps1

### DIFF
--- a/tiled/tiled_catalog_register.ps1
+++ b/tiled/tiled_catalog_register.ps1
@@ -36,14 +36,6 @@ if (-not ([string]::IsNullOrWhiteSpace($Env:PATH_TO_PROCESSED_DATA_CATALOG)) -an
 if (-not ([string]::IsNullOrWhiteSpace("$Env:PATH_TO_PROCESSED_DATA")) -and (Test-Path "$Env:PATH_TO_PROCESSED_DATA" -PathType Container)){
     tiled register $Env:TILED_URI --verbose `
     --prefix "/processed" `
-    --ext '.edf=application/x-edf' `
-    --adapter 'application/x-edf=custom.edf:read' `
-    --ext '.gb=application/x-gb' `
-    --adapter 'application/x-gb=custom.gb:read' `
-    --ext '.cbf=application/x-cbf' `
-    --adapter 'application/x-cbf=custom.cbf:read' `
-    --walker 'custom.lambda_nxs:walk' `
-    --adapter 'multipart/related;type=application/x-hdf5=custom.lambda_nxs:read_sequence' `
     "$Env:PATH_TO_PROCESSED_DATA"
 } else {
     Write-Host "The directory for processed data ($Env:PATH_TO_PROCESSED_DATA) does not exist."

--- a/tiled/tiled_catalog_register.ps1
+++ b/tiled/tiled_catalog_register.ps1
@@ -7,8 +7,8 @@ Write-Host "Data catalog for raw data: $Env:PATH_TO_RAW_DATA_CATALOG"
 Write-Host "Data catalog for processed data: $Env:PATH_TO_PROCESSED_DATA_CATALOG"
 
 # Should no longer be needed since tiled serve comes first
-if (-not ([string]::IsNullOrWhiteSpace($Env:PATH_TO_DATA_CATALOG)) -and -not (Test-Path "$Env:PATH_TO_DATA_CATALOG")) {
-    tiled catalog init "$Env:PATH_TO_DATA_CATALOG"
+if (-not ([string]::IsNullOrWhiteSpace($Env:PATH_TO_RAW_DATA_CATALOG)) -and -not (Test-Path "$Env:PATH_TO_RAW_DATA_CATALOG")) {
+    tiled catalog init "$Env:PATH_TO_RAW_DATA_CATALOG"
 }
 
 ## Will overwrite
@@ -24,5 +24,28 @@ if (-not ([string]::IsNullOrWhiteSpace("$Env:PATH_TO_RAW_DATA")) -and (Test-Path
     "$Env:PATH_TO_RAW_DATA"
 } else {
     Write-Host "The directory for raw data ($Env:PATH_TO_RAW_DATA) does not exist."
+}
+
+
+# Should no longer be needed since tiled serve comes first
+if (-not ([string]::IsNullOrWhiteSpace($Env:PATH_TO_PROCESSED_DATA_CATALOG)) -and -not (Test-Path "$Env:PATH_TO_PROCESSED_DATA_CATALOG")) {
+    tiled catalog init "$Env:PATH_TO_PROCESSED_DATA_CATALOG"
+}
+
+## Will overwrite
+if (-not ([string]::IsNullOrWhiteSpace("$Env:PATH_TO_PROCESSED_DATA")) -and (Test-Path "$Env:PATH_TO_PROCESSED_DATA" -PathType Container)){
+    tiled register $Env:TILED_URI --verbose `
+    --prefix "/processed" `
+    --ext '.edf=application/x-edf' `
+    --adapter 'application/x-edf=custom.edf:read' `
+    --ext '.gb=application/x-gb' `
+    --adapter 'application/x-gb=custom.gb:read' `
+    --ext '.cbf=application/x-cbf' `
+    --adapter 'application/x-cbf=custom.cbf:read' `
+    --walker 'custom.lambda_nxs:walk' `
+    --adapter 'multipart/related;type=application/x-hdf5=custom.lambda_nxs:read_sequence' `
+    "$Env:PATH_TO_PROCESSED_DATA"
+} else {
+    Write-Host "The directory for processed data ($Env:PATH_TO_PROCESSED_DATA) does not exist."
 }
     

--- a/tiled/tiled_catalog_register.sh
+++ b/tiled/tiled_catalog_register.sh
@@ -15,16 +15,6 @@ if [ -d "$PATH_TO_PROCESSED_DATA" ]; then
      tiled register $TILED_URI --verbose \
             --api-key $TILED_API_KEY \
             --prefix "/processed" \
-            --ext '.cbf=application/x-cbf' \
-            --adapter 'application/x-cbf=custom.cbf:read' \
-            --ext '.edf=application/x-edf' \
-            --adapter 'application/x-edf=custom.edf:read' \
-            --ext '.gb=application/x-gb' \
-            --adapter 'application/x-gb=custom.gb:read' \
-            --walker 'custom.blacklist:walk' \
-            --walker 'custom.whitelist:walk' \
-            --walker 'custom.lambda_nxs:walk' \
-            --adapter 'multipart/related;type=application/x-hdf5=custom.lambda_nxs:read_sequence' \
             "$PATH_TO_PROCESSED_DATA"
 else
     echo "The directory for raw data ($PATH_TO_PROCESSED_DATA) does not exist."


### PR DESCRIPTION
The current powershell script on main does not ingest the processed data into its own Tiled catalog. This PR was tested on the viz-lab machine. Small modifications were made to the raw data ingestion part of the script to search for the `PATH_TO_RAW_DATA_CATALOG` instead of `PATH_TO_DATA_CATALOG`.