### PR TITLE
Fixes for startup up from docker-compose

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,72 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Create and publish image
+
+on:
+  push:
+    branches: ['main']
+    tags: ['v*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  TEST_TAG: user/app:test
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build for test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          tags: ${{ env.TEST_TAG }}
+
+      - name: Test
+        run: |
+          CONTAINER_ID=$(docker run -d --rm ${{ env.TEST_TAG }})
+          sleep 5  # Allow time for the server to start
+          docker logs $CONTAINER_ID  # Show logs to confirm it's running
+          docker stop $CONTAINER_ID  # Stop the container
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,33 @@
+name: build and test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install .[dev]
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
-        pip install .[dev]
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,6 +28,8 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+    
+    #   no tests exist yet
+    # - name: Test with pytest
+    #   run: |
+    #     pytest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
 
   workflow-viz:
     image: workflow_viz
+    build: .
     container_name: workflow_viz
     command: 'python app.py'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,13 @@
 version: "3"
 services:
   tiled:
-    image: workflow_viz
+    image: ghcr.io/bluesky/tiled:0.1.0-b17
     container_name: tiled_workflow_server
     command: bash -c "/app/tiled/tiled_config_serve.sh"
     volumes:
       - ./tiled:/app/tiled
       #- desy-drive:/data
-      - .env:/app/.env
+      - .env:/deploy/.env
       - ${PATH_TO_RAW_DATA}:/data
     environment:
       TILED_API_KEY: ${TILED_API_KEY}
@@ -56,8 +56,6 @@ services:
       - ./utils:/app/utils
     ports:
       - '8095:8095'
-    depends_on:
-      - tiled
     networks:
       - workflow_viz_default
 

--- a/metadata_app.py
+++ b/metadata_app.py
@@ -1,8 +1,7 @@
 import dash
 from dash import html
 
-from callbacks.metadata_interface import * #noqa: F401, F403
-
+from callbacks.metadata_interface import *  # noqa: F401, F403
 from components.metadata_interface import (
     interface_components,
     table_modification_components,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dash==2.13.0
 dash-html-components==2.0.0
 dash-core-components==2.0.0
 dash-mantine-components==0.12.1
-griffe >= 0.49.0, <2.0.0
+griffe == 0.49.0
 numpy==1.26.0
 scipy==1.11.3
 dash-iconify==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ dash==2.13.0
 dash-html-components==2.0.0
 dash-core-components==2.0.0
 dash-mantine-components==0.12.1
+griffe >= 0.49.0, <2.0.0
 numpy==1.26.0
 scipy==1.11.3
 dash-iconify==0.1.2

--- a/tiled/tiled_config_serve.sh
+++ b/tiled/tiled_config_serve.sh
@@ -4,7 +4,7 @@ set -o allexport
 source .env
 set +o allexport
 export TILED_SINGLE_USER_API_KEY=$TILED_API_KEY
-pip install fabio
+
 # Replace environment variables in config.yml
 # envsubst < ./tiled/config/config.yml > ./tiled/config/config_tmp.yml
 tiled serve config /app/tiled/config/config.yml

--- a/tiled/tiled_config_serve.sh
+++ b/tiled/tiled_config_serve.sh
@@ -7,4 +7,4 @@ export TILED_SINGLE_USER_API_KEY=$TILED_API_KEY
 
 # Replace environment variables in config.yml
 # envsubst < ./tiled/config/config.yml > ./tiled/config/config_tmp.yml
-tiled serve config /app/tiled/config/config.yml
+tiled serve config .tiled/config/config.yml

--- a/tiled/tiled_config_serve.sh
+++ b/tiled/tiled_config_serve.sh
@@ -4,7 +4,7 @@ set -o allexport
 source .env
 set +o allexport
 export TILED_SINGLE_USER_API_KEY=$TILED_API_KEY
-
+pip install fabio
 # Replace environment variables in config.yml
-envsubst < ./tiled/config/config.yml > ./tiled/config/config_tmp.yml
-tiled serve config ./tiled/config/config_tmp.yml
+# envsubst < ./tiled/config/config.yml > ./tiled/config/config_tmp.yml
+tiled serve config /app/tiled/config/config.yml


### PR DESCRIPTION
A few fixes to startup a working system from docker-compose.yml:

1. Removed 1envsubst`. Tiled does environment variable substitution: https://github.com/bluesky/tiled/blob/a98122fa2ef8abce79c1f6b594156207d06b2725/tiled/utils.py#L480

2. Workdir for tiled is /deploy

3. Adds github actions to build, lint, test and publish container to github. Also, runs container and tests that the service starts.