### PR TITLE
startup checks on tiled server

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,18 @@
 import dash_mantine_components as dmc
 from dash import Dash, dcc, html
 
+try:
+    import utils.data_retrieval
+except Exception as e:
+    import sys
+
+    print(
+        "Error importing utils.data_retrieval. "
+        "This is often caused by not being able to connect to the Tiled server. "
+        f"Error: {e}"
+    )
+    sys.exit(1)
+
 from callbacks.config_loader import *
 from callbacks.controls_calibration import *
 from callbacks.controls_reduction import *

--- a/utils/data_retrieval.py
+++ b/utils/data_retrieval.py
@@ -15,8 +15,15 @@ load_dotenv()
 TILED_URI = os.getenv("TILED_URI")
 TILED_API_KEY = os.getenv("TILED_API_KEY")
 
-client = from_uri(TILED_URI, api_key=TILED_API_KEY)
-TILED_BASE_URI = client.uri
+if TILED_URI is None or TILED_API_KEY is None:
+    raise ValueError("TILED_URI and TILED_API_KEY must be set in the .env file")
+
+try:
+    client = from_uri(TILED_URI, api_key=TILED_API_KEY)
+    TILED_BASE_URI = client.uri
+except Exception as e:
+    error_message = f"Error connecting to Tiled server: {e}"
+    raise ValueError(error_message)
 
 
 def trim_base_from_uri(uri_to_trim):


### PR DESCRIPTION
The app has some pretty unfriendly exceptions when it can't connect to the tiled server on startup.

This PR catches these early and sends a friendlier messge to the user. A more comprehensive change might be to take the tiled client initialization out of the data_retrieval module and move it into a method in app. But that's more work.