### PR TITLE
Add reduction parameters for horizontal cut on grazing incidence scans

### DIFF
--- a/callbacks/config_loader.py
+++ b/callbacks/config_loader.py
@@ -44,7 +44,7 @@ def apply_config_import(apply, parameters):
         "beamcenter_x",
         "beamcenter_y",
         "wavelength",
-        "incident-angle",
+        "incident_angle",
         "pix_size",
         "sample_detector_dist",
         "rotation",

--- a/callbacks/controls_reduction.py
+++ b/callbacks/controls_reduction.py
@@ -81,11 +81,27 @@ def submit_reduction_to_compute(
 
 @callback(
     Output("controls-reduction", "style"),
+    Output("controls-reduction-integration", "style"),
+    Output("controls-reduction-cut", "style"),
+    Input("experiment-type", "value"),
     Input("progress-stepper", "active"),
 )
-def toggle_controls_reduction_visibility(current_step):
+def toggle_controls_reduction_visibility(experiment_type, current_step):
     step = current_step if current_step is not None else 0
     if step == 1:
-        return {"display": "block"}
+        if experiment_type is not None and experiment_type.startswith("GI"):
+            # Show cut controls, hide integration
+            return (
+                {"display": "block"},
+                {"display": "none"},
+                {"display": "flex"},
+            )
+        else:
+            # Show integration controls, hide cut
+            return (
+                {"display": "block"},
+                {"display": "flex"},
+                {"display": "none"},
+            )
     else:
-        return {"display": "none"}
+        return {"display": "none"}, {"display": "none"}, {"display": "none"}

--- a/callbacks/controls_reduction.py
+++ b/callbacks/controls_reduction.py
@@ -54,7 +54,7 @@ def submit_reduction_to_compute(
     horizontal_cut_half_width,
     horizontal_cut_pos_y,
     horizontal_cut_x_min,
-    horizontal_x_max,
+    horizontal_cut_x_max,
 ):
     if n_clicks:
         scan_uri = scan_name_uri_mapper[scan_name]
@@ -74,7 +74,7 @@ def submit_reduction_to_compute(
                 "cut_half_width": horizontal_cut_half_width,
                 "cut_pos_y": horizontal_cut_pos_y,
                 "x_min": horizontal_cut_x_min,
-                "x_max": horizontal_x_max,
+                "x_max": horizontal_cut_x_max,
             }
             parameters = {
                 **parameters_calibration,
@@ -136,3 +136,18 @@ def toggle_controls_reduction_visibility(experiment_type, current_step):
             )
     else:
         return {"display": "none"}, {"display": "none"}, {"display": "none"}
+
+
+@callback(
+    Output("horizontal-cut-pos-y", "value"),
+    Output("horizontal-x-max", "value"),
+    Input("beamcenter-y", "value"),
+    Input("scan-dims", "data"),
+)
+def set_default_cut_positions(
+    beamcenter_y,
+    scan_dims,
+):
+    scan_width = scan_dims["width"]
+    # Set suggested cut position 100 pixels above (visually, lower in y) the beamcenter
+    return beamcenter_y - 100, scan_width

--- a/callbacks/controls_reduction.py
+++ b/callbacks/controls_reduction.py
@@ -11,6 +11,7 @@ from utils.prefect import get_full_deployment_names, schedule_prefect_flow
     State("scan-name-uri-map", "data"),
     State("mask-name", "value"),
     State("mask-name-uri-map", "data"),
+    State("experiment-type", "value"),
     State("beamcenter-x", "value"),
     State("beamcenter-y", "value"),
     State("wavelength", "value"),
@@ -24,6 +25,10 @@ from utils.prefect import get_full_deployment_names, schedule_prefect_flow
     State("radial-range-max", "value"),
     State("azimuthal-range-min", "value"),
     State("azimuthal-range-max", "value"),
+    State("horizontal-cut-half-width", "value"),
+    State("horizontal-cut-pos-y", "value"),
+    State("horizontal-x-min", "value"),
+    State("horizontal-x-max", "value"),
     prevent_initial_call=True,
 )
 def submit_reduction_to_compute(
@@ -32,6 +37,7 @@ def submit_reduction_to_compute(
     scan_name_uri_mapper,
     mask_name,
     mask_name_uri_mapper,
+    experiment_type,
     beamcenter_x,
     beamcenter_y,
     wavelength,
@@ -45,29 +51,54 @@ def submit_reduction_to_compute(
     radial_range_max,
     azimuthal_range_min,
     azimuthal_range_max,
+    horizontal_cut_half_width,
+    horizontal_cut_pos_y,
+    horizontal_cut_x_min,
+    horizontal_x_max,
 ):
     if n_clicks:
         scan_uri = scan_name_uri_mapper[scan_name]
         mask_uri = mask_name_uri_mapper[mask_name]
-        parameters = {
+        parameters_calibration = {
             "input_uri_data": scan_uri,
             "input_uri_mask": mask_uri,
             "beamcenter_x": beamcenter_x,
             "beamcenter_y": beamcenter_y,
             "wavelength": wavelength,
-            "polarization_factor": 0.99,
             "sample_detector_dist": sample_detector_dist,
             "pix_size": pix_size,
-            "rotation": detector_rotation,
-            "tilt": detector_tilt,
-            "num_bins": num_bins_integration,
-            "chi_min": azimuthal_range_min,
-            "chi_max": azimuthal_range_max,
-            "inner_radius": radial_range_min,
-            "outer_radius": radial_range_max,
             "output_unit": "q",  # "q"
         }
-        flow_name = "integration-azimuthal"
+        if experiment_type is not None and experiment_type.startswith("GI"):
+            parameters_cut = {
+                "cut_half_width": horizontal_cut_half_width,
+                "cut_pos_y": horizontal_cut_pos_y,
+                "x_min": horizontal_cut_x_min,
+                "x_max": horizontal_x_max,
+            }
+            parameters = {
+                **parameters_calibration,
+                **parameters_cut,
+                "incident_angle": incident_angle,
+            }
+            flow_name = "horizontal-cut"
+        else:
+            parameters_integration = {
+                "num_bins": num_bins_integration,
+                "chi_min": azimuthal_range_min,
+                "chi_max": azimuthal_range_max,
+                "inner_radius": radial_range_min,
+                "outer_radius": radial_range_max,
+            }
+            parameters = {
+                **parameters_calibration,
+                **parameters_integration,
+                "polarization_factor": 0.99,
+                "rotation": detector_rotation,
+                "tilt": detector_tilt,
+            }
+            flow_name = "integration-azimuthal"
+
         reduction_flows = get_full_deployment_names()
         deployment_name = reduction_flows[flow_name]
         flow_run_id = schedule_prefect_flow(deployment_name, parameters)

--- a/callbacks/scan.py
+++ b/callbacks/scan.py
@@ -31,15 +31,15 @@ def upate_scan(scan_name, mask_name, scan_name_uri_map, mask_name_uri_map):
         )
         figure = go.Figure(data=scan, layout=SCAN_FIGURE_LAYOUT)
     else:
-        scan_width = 1679
-        scan_height = 1475
+        scan_height = 1679
+        scan_width = 1475
         # data = generate_zeros(width=scan_width, height=scan_height)
         figure = go.Figure(go.Scatter(x=[], y=[]))
     if mask_name:
         mask_uri = mask_name_uri_map[mask_name]
         mask_data = get_mask_data(
             mask_uri, scan_height=scan_height, scan_width=scan_width
-        ).astype(np.uint8)
+        )
         if mask_data is not None:
             # Masks exported from Igor have zeros for areas to be masked out
             # Masks exported from pyFAI have non-zero values for these areas
@@ -50,7 +50,11 @@ def upate_scan(scan_name, mask_name, scan_name_uri_map, mask_name_uri_map):
                 [1, "rgba(0, 0, 0, 1)"],
             ]
             figure.add_trace(
-                go.Heatmap(z=mask_data, colorscale=mask_colorscale, showscale=False)
+                go.Heatmap(
+                    z=mask_data.astype(np.uint8),
+                    colorscale=mask_colorscale,
+                    showscale=False,
+                )
             )
             figure["data"][1]["opacity"] = 1 / 2
     figure["layout"]["yaxis"]["autorange"] = "reversed"

--- a/callbacks/scan.py
+++ b/callbacks/scan.py
@@ -5,7 +5,7 @@ from dash import Input, Output, Patch, State, callback, ctx, no_update
 from dash.exceptions import PreventUpdate
 
 from components.scan import SCAN_FIGURE_LAYOUT
-from utils.create_shapes import create_cross
+from utils.create_shapes import create_cross, create_rect_center_line
 from utils.data_retrieval import get_mask_data, get_scan_data
 
 
@@ -109,3 +109,79 @@ def update_beamcenter_indicator(
         return patched_figure, no_update, no_update
 
     return patched_figure, x_value, y_value
+
+
+@callback(
+    Output("scan-viewer", "figure", allow_duplicate=True),
+    Output("horizontal-cut-pos-y", "value", allow_duplicate=True),
+    Output("horizontal-x-min", "value", allow_duplicate=True),
+    Output("horizontal-x-max", "value", allow_duplicate=True),
+    Input("scan-viewer", "clickData"),
+    State("scan-viewer", "figure"),
+    State("experiment-type", "value"),
+    Input("horizontal-cut-pos-y", "value"),
+    Input("horizontal-cut-half-width", "value"),
+    Input("horizontal-x-min", "value"),
+    Input("horizontal-x-max", "value"),
+    Input("progress-stepper", "active"),
+    State("scan-dims", "data"),
+    prevent_initial_call=True,
+)
+def update_horizontal_cut_indicator(
+    click_data,
+    fig,
+    experiment_type,
+    horizontal_cut_pos_y,
+    horizontal_cut_half_width,
+    horizontal_cut_x_min,
+    horizontal_cut_x_max,
+    current_step,
+    scan_dims,
+):
+    if current_step != 1 or (
+        experiment_type is not None and not experiment_type.startswith("GI")
+    ):
+        raise PreventUpdate
+
+    scan_width = scan_dims["width"]
+    scan_height = scan_dims["height"]
+
+    trigger = ctx.triggered_id
+    if click_data is not None and trigger == "scan-viewer":
+        x_value = click_data["points"][0]["x"]
+        y_value = click_data["points"][0]["y"]
+        # Assume that the user wants the width of the cut to stay the
+        old_width = horizontal_cut_x_max - horizontal_cut_x_min + 1
+        x_min = max(0, int(x_value - old_width / 2))
+        x_max = min(scan_width - 1, int(x_value + old_width / 2))
+    else:
+        x_value = (horizontal_cut_x_min + horizontal_cut_x_max) / 2
+        y_value = horizontal_cut_pos_y
+        x_min = horizontal_cut_x_min
+        x_max = horizontal_cut_x_max
+
+    rect, center_line = create_rect_center_line(
+        center_x=x_value,
+        center_y=y_value,
+        rect_width=horizontal_cut_x_max - horizontal_cut_x_min + 1,
+        rect_height=horizontal_cut_half_width * 2 + 1,
+        scan_width=scan_width,
+        scan_height=scan_height,
+    )
+
+    patched_figure = Patch()
+
+    current_shapes = fig.get("layout", {}).get("shapes", [])
+
+    if len(current_shapes) < 4:
+        patched_figure["layout"]["shapes"].append(rect)
+        patched_figure["layout"]["shapes"].append(center_line)
+    else:
+        patched_figure["layout"]["shapes"][2] = rect
+        patched_figure["layout"]["shapes"][3] = center_line
+
+    y_update = y_value if y_value != horizontal_cut_pos_y else no_update
+    x_min_update = x_min if x_min != horizontal_cut_x_min else no_update
+    x_max_update = x_max if x_max != horizontal_cut_x_max else no_update
+
+    return patched_figure, y_update, x_min_update, x_max_update

--- a/callbacks/scan.py
+++ b/callbacks/scan.py
@@ -1,7 +1,7 @@
 # import plotly.express as px
 import numpy as np
 import plotly.graph_objects as go
-from dash import Input, Output, Patch, State, callback
+from dash import Input, Output, Patch, State, callback, ctx, no_update
 from dash.exceptions import PreventUpdate
 
 from components.scan import SCAN_FIGURE_LAYOUT
@@ -66,31 +66,46 @@ def upate_scan(scan_name, mask_name, scan_name_uri_map, mask_name_uri_map):
     Output("beamcenter-x", "value"),
     Output("beamcenter-y", "value"),
     Input("scan-viewer", "clickData"),
-    State("scan-dims", "data"),
+    Input("beamcenter-x", "value"),
+    Input("beamcenter-y", "value"),
     State("progress-stepper", "active"),
+    State("scan-dims", "data"),
     prevent_initial_call=True,
 )
-def handle_click(
+def update_beamcenter_indicator(
     click_data,
+    beamcenter_x,
+    beamcenter_y,
     current_step,
     scan_dims,
 ):
-    if current_step != 1:
+    if current_step != 0:
         raise PreventUpdate
+
     scan_width = scan_dims["width"]
     scan_height = scan_dims["height"]
-    if click_data is not None:
+
+    trigger = ctx.triggered_id
+    if click_data is not None and trigger == "scan-viewer":
         x_value = click_data["points"][0]["x"]
         y_value = click_data["points"][0]["y"]
     else:
-        x_value = scan_width / 2
-        y_value = scan_height / 2
+        x_value = beamcenter_x
+        y_value = beamcenter_y
+
     patched_figure = Patch()
 
     horizontal_line, vertical_line = create_cross(
-        x_value, y_value, 200, 200, scan_width, scan_height
+        x_value, y_value, 50, 50, scan_width, scan_height
     )
+
+    # A placeholder cross for the beamcenter was added on initialization
+    # We can simply update these two lines here
     patched_figure["layout"]["shapes"][0].update(horizontal_line)
-    patched_figure["layout"]["shapes"][0].update(vertical_line)
+    patched_figure["layout"]["shapes"][1].update(vertical_line)
+
+    # Prevent unneccessary update to beamcenter number inputs
+    if x_value == beamcenter_x and y_value == beamcenter_y:
+        return patched_figure, no_update, no_update
 
     return patched_figure, x_value, y_value

--- a/components/controls_calibration.py
+++ b/components/controls_calibration.py
@@ -107,6 +107,7 @@ def layout():
                     id="incident-angle",
                     value=0,
                     precision=3,
+                    step=0.01,
                     size="sm",
                     stepHoldDelay=500,
                     stepHoldInterval=1,

--- a/components/controls_reduction.py
+++ b/components/controls_reduction.py
@@ -15,7 +15,8 @@ def layout():
     # radial_vs_azimuthal = dmc.Switch()
     # game-icons:radial-balance
 
-    constrols_integration = dmc.Grid(
+    controls_integration = dmc.Grid(
+        id="controls-reduction-integration",
         children=[
             dmc.Col(
                 dmc.NumberInput(
@@ -94,14 +95,80 @@ def layout():
                 ),
                 span=3,
             ),
-        ]
+        ],
+    )
+
+    controls_horizontal_cut = dmc.Grid(
+        id="controls-reduction-cut",
+        children=[
+            dmc.Col(
+                dmc.NumberInput(
+                    label="Cut Position in Y",
+                    description="in pixel [0, ...]",
+                    id="cut-pos-y",
+                    value=0,
+                    precision=0,
+                    size="sm",
+                    stepHoldDelay=500,
+                    stepHoldInterval=100,
+                    persistence=True,
+                    persistence_type="session",
+                ),
+                span=3,
+            ),
+            dmc.Col(
+                dmc.NumberInput(
+                    label="Half Width of Cut",
+                    description="in pixel [0, ...]",
+                    id="horizontal-cut-half-width",
+                    type="number",
+                    value=5,
+                    precision=0,
+                    size="sm",
+                    stepHoldDelay=500,
+                    stepHoldInterval=100,
+                    persistence=True,
+                    persistence_type="session",
+                ),
+                span=3,
+            ),
+            dmc.Col(
+                dmc.NumberInput(
+                    label="X Min",
+                    description="in pixel [0, ...]",
+                    id="horizontal-x-min",
+                    value=0,
+                    precision=0,
+                    size="sm",
+                    stepHoldDelay=500,
+                    stepHoldInterval=1,
+                ),
+                span=3,
+            ),
+            dmc.Col(
+                dmc.NumberInput(
+                    label="X Max",
+                    description="in pixel [0, ...]",
+                    id="horizontal-x-max",
+                    value=0,
+                    precision=0,
+                    size="sm",
+                    stepHoldDelay=500,
+                    stepHoldInterval=100,
+                    persistence=True,
+                    persistence_type="session",
+                ),
+                span=3,
+            ),
+        ],
     )
 
     return html.Div(
         id="controls-reduction",
         style=COMPONENT_STYLE,
         children=[
-            constrols_integration,
+            controls_integration,
+            controls_horizontal_cut,
             dmc.Space(h=20),
             dmc.Center(
                 dmc.Button(

--- a/components/controls_reduction.py
+++ b/components/controls_reduction.py
@@ -105,7 +105,7 @@ def layout():
                 dmc.NumberInput(
                     label="Cut Position in Y",
                     description="in pixel [0, ...]",
-                    id="cut-pos-y",
+                    id="horizontal-cut-pos-y",
                     value=0,
                     precision=0,
                     size="sm",

--- a/components/scan.py
+++ b/components/scan.py
@@ -33,7 +33,13 @@ def layout():
     figure = go.Figure(go.Scatter(x=[], y=[]), layout=SCAN_FIGURE_LAYOUT)
 
     horizontal_line, vertical_line = create_cross(
-        scan_width / 2, scan_height / 2, 20, 20, scan_width, scan_height
+        scan_width / 2,
+        scan_height / 2,
+        20,
+        20,
+        scan_width,
+        scan_height,
+        line_color="white",
     )
 
     figure.add_shape(horizontal_line)

--- a/tiled/tiled_config_serve.sh
+++ b/tiled/tiled_config_serve.sh
@@ -7,4 +7,4 @@ export TILED_SINGLE_USER_API_KEY=$TILED_API_KEY
 
 # Replace environment variables in config.yml
 # envsubst < ./tiled/config/config.yml > ./tiled/config/config_tmp.yml
-tiled serve config .tiled/config/config.yml
+tiled serve config ./tiled/config/config.yml

--- a/utils/create_shapes.py
+++ b/utils/create_shapes.py
@@ -8,8 +8,8 @@ def create_cross(
     height,
     scan_width,
     scan_height,
-    line_color="white",
-    line_width=5,
+    line_color="red",
+    line_width=3,
 ):
     horizontal_line = go.layout.Shape(
         type="line",

--- a/utils/create_shapes.py
+++ b/utils/create_shapes.py
@@ -8,7 +8,7 @@ def create_cross(
     height,
     scan_width,
     scan_height,
-    line_color="red",
+    line_color="rgba(255, 0, 0, 0.7)",
     line_width=3,
 ):
     horizontal_line = go.layout.Shape(
@@ -30,17 +30,20 @@ def create_cross(
     return horizontal_line, vertical_line
 
 
-def create_rect(
+def create_rect_center_line(
     center_x,
     center_y,
     rect_width,
     rect_height,
     scan_width,
     scan_height,
-    line_color="black",
-    line_width=5,
+    line_color="rgba(255, 255, 255, 0.7)",
+    line_width=3,
+    line_width_center=1,
+    horizontal=True,
 ):
-    return go.layout.Shape(
+    # Define the rectangle
+    rect = go.layout.Shape(
         type="rect",
         x0=max(0, int(center_x - rect_width / 2)),
         y0=max(0, int(center_y - rect_height / 2)),
@@ -48,3 +51,25 @@ def create_rect(
         y1=min(scan_height - 1, int(center_y + rect_height / 2)),
         line=dict(color=line_color, width=line_width),
     )
+
+    # Define the center line (dashed)
+    if horizontal:
+        center_line = go.layout.Shape(
+            type="line",
+            x0=max(0, int(center_x - rect_width / 2)),
+            y0=center_y,
+            x1=min(scan_width - 1, int(center_x + rect_width / 2)),
+            y1=center_y,
+            line=dict(color=line_color, width=line_width_center, dash="dash"),
+        )
+    else:
+        center_line = go.layout.Shape(
+            type="line",
+            x0=center_x,
+            y0=max(0, int(center_y - rect_height / 2)),
+            x1=center_x,
+            y1=min(scan_height - 1, int(center_y + rect_height / 2)),
+            line=dict(color=line_color, width=line_width_center, dash="dash"),
+        )
+
+    return rect, center_line

--- a/utils/data_retrieval.py
+++ b/utils/data_retrieval.py
@@ -1,6 +1,5 @@
 import os
 
-import numpy as np
 from dotenv import load_dotenv
 from tiled.client import from_uri
 from tiled.client.array import ArrayClient
@@ -181,11 +180,6 @@ def get_mask_data(trimmed_mask_uri, scan_height, scan_width, downsample_factor=1
     mask = from_uri(TILED_BASE_URI + trimmed_mask_uri, api_key=TILED_API_KEY)
     if mask.shape[0] == scan_height and mask.shape[1] == scan_width:
         return mask[::downsample_factor, ::downsample_factor]
-    # Rotated?
-    elif mask.shape[0] == scan_width and mask.shape[1] == scan_height:
-        flipped = np.flipud(mask)
-        rotated = np.rot90(flipped[::downsample_factor, ::downsample_factor], 3)
-        return rotated
     else:
         print("Mask dimensions and scan dimensions don't match.")
         return None


### PR DESCRIPTION
This PR completes the integration of reduction parameters for grazing incidence (horizontal cuts), reinstates the interactive shape overlays for beamcenter (clickable in calibration step, red at 70% opacity) and adds an interactive shape overlay for the horizontal cut (adapting the position in y and retaining the previously used width defined by `x_min` and `x_max`, clickable in reduction step). 

![Screenshot 2025-02-15 at 14 58 55](https://github.com/user-attachments/assets/e9bd2e9c-0401-49ad-8659-176e3ffd4783)
