### PR TITLE
Add debug config for `tiled register`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -79,18 +79,18 @@
         {
             "type": "promptString",
             "id": "tiledUri",
-            "description": "Specify the URI of the running Tiled server to register data with. Same as environment variable TILED_URI.",
+            "description": "Specify the URI of the running Tiled server by copying the value for TILED_URI in .env without quotes.",
             "default": "http://localhost:8888"
         },
         {
             "type": "promptString",
             "id": "tiledApiKey",
-            "description": "Specify the API key for the Tiled server. Same as environment variable TILED_API_KEY.",
+            "description": "Specify the API key for the Tiled server by copying the value for TILED_API_KEY in .env without quotes."
         },
         {
             "type": "promptString",
             "id": "tiledPathToRawData",
-            "description": "Specify the path to the raw data to register. Same as environment variable PATH_TO_RAW_DATA.",
+            "description": "Specify the path to the raw data by copying the value for PATH_TO_RAW_DATA in .env without quotes."
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,5 +33,64 @@
             ],
             "justMyCode": false,
         },
+        {
+            "name": "Debug Tiled Registration",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "tiled",
+            "args": [
+                "register",
+                "${input:tiledUri}",
+                "--verbose",
+                "--api-key",
+                "${input:tiledApiKey}",
+                "--prefix",
+                "/raw",
+                "--ext",
+                ".cbf=application/x-cbf",
+                "--adapter",
+                "application/x-cbf=custom.cbf:read",
+                "--ext",
+                ".edf=application/x-edf",
+                "--adapter",
+                "application/x-edf=custom.edf:read",
+                "--ext",
+                ".gb=application/x-gb",
+                "--adapter",
+                "application/x-gb=custom.gb:read",
+                "--walker",
+                "custom.blacklist:walk",
+                "--walker",
+                "custom.whitelist:walk",
+                "--walker",
+                "custom.lambda_nxs:walk",
+                "--adapter",
+                "multipart/related;type=application/x-hdf5=custom.lambda_nxs:read_sequence",
+                "${input:tiledPathToRawData}"
+            ],
+            "justMyCode": false,
+            "console": "integratedTerminal",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/tiled/config/"
+            }
+        },
+    ],
+    "inputs": [
+        {
+            "type": "promptString",
+            "id": "tiledUri",
+            "description": "Specify the URI of the running Tiled server to register data with. Same as environment variable TILED_URI.",
+            "default": "http://localhost:8888"
+        },
+        {
+            "type": "promptString",
+            "id": "tiledApiKey",
+            "description": "Specify the API key for the Tiled server. Same as environment variable TILED_API_KEY.",
+        },
+        {
+            "type": "promptString",
+            "id": "tiledPathToRawData",
+            "description": "Specify the path to the raw data to register. Same as environment variable PATH_TO_RAW_DATA.",
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug App",
+            "name": "Debug Frontend App",
             "type": "debugpy",
             "request": "launch",
             "module": "flask",
@@ -22,14 +22,14 @@
             "jinja": true
         },
         {
-            "name": "Debug Tiled",
+            "name": "Debug Tiled Serve",
             "type": "debugpy",
             "request": "launch",
             "module": "tiled",
             "args": [
                 "serve",
                 "config",
-                "./tiled/config/config_tmp.yml"
+                "./tiled/config/config.yml"
             ],
             "justMyCode": false,
         },

--- a/tiled/config/config.yml
+++ b/tiled/config/config.yml
@@ -42,4 +42,4 @@ uvicorn:
 authentication:
   # For local testing allow anonymous access
   allow_anonymous_access: true
-  single_user_api_key: $TILED_SINGLE_USER_API_KEY
+  single_user_api_key: $TILED_API_KEY

--- a/tiled/tiled_catalog_register.sh
+++ b/tiled/tiled_catalog_register.sh
@@ -17,7 +17,7 @@ if [ -d "$PATH_TO_PROCESSED_DATA" ]; then
             --prefix "/processed" \
             "$PATH_TO_PROCESSED_DATA"
 else
-    echo "The directory for raw data ($PATH_TO_PROCESSED_DATA) does not exist."
+    echo "The directory for processed data ($PATH_TO_PROCESSED_DATA) does not exist."
 fi
 
 # Should no longer be needed since tiled serve comes first

--- a/tiled/tiled_config_serve.ps1
+++ b/tiled/tiled_config_serve.ps1
@@ -1,5 +1,4 @@
 # equivalent to "source .env"
 ./set_env.ps1
-$Env:TILED_SINGLE_USER_API_KEY=$Env:TILED_API_KEY
 
 tiled serve config ./tiled/config/config.yml

--- a/tiled/tiled_config_serve.sh
+++ b/tiled/tiled_config_serve.sh
@@ -3,7 +3,6 @@
 set -o allexport
 source .env
 set +o allexport
-export TILED_SINGLE_USER_API_KEY=$TILED_API_KEY
 
 # Replace environment variables in config.yml
 # envsubst < ./tiled/config/config.yml > ./tiled/config/config_tmp.yml


### PR DESCRIPTION
This PR adds a VS Code configuration for debugging the `tiled register` process. It requires an already running Tiled server instance and the parameters specified within the input prompts need to match the configuration from that running process.
The added launch configuration is equivalent to the script under [tiled/tiled_catalog_register.sh](https://github.com/mlexchange/workflow-viz/blob/72f0e1c85f5c4a6069c9ed1a3be8394c97904196/tiled/tiled_catalog_register.sh#L29-L43)

The reasons for not retrieving these parameters from environment variables (as in the script linked above) are explained in #10. In short, environment variables are resolved only after the launch configuration is assembled and can thus not be used within the command. 

This PR also resolves #10, and includes an update to the `tiled serve` debug configuration.