### PR TITLE
allow user-input field for apikey in tiled viewer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tiled[all]==0.1.0a116
 gunicorn
 typer
 dash-extensions==1.0.7
-tiled-viewer==0.0.3
+tiled-viewer==0.0.5


### PR DESCRIPTION
increment tiled-viewer to version 0.0.5

-when in button mode, the user can enter an api key manually
-the user defined api key is saved to local storage so it only needs to be entered once if it doesn't change
-the user input row with apikey and button to open tiled viewer now remains on the screen when the viewer modal opens
-viewer modal can be closed by clicking outside